### PR TITLE
fix(live): tree-sitter overlay position mismatch and stale overlay reuse

### DIFF
--- a/md-mermaid-live.el
+++ b/md-mermaid-live.el
@@ -1009,15 +1009,12 @@ Detects scroll direction and expands prefetch to prevent upward-scroll flicker."
          (content (buffer-substring-no-properties code-beg code-end))
          (code-lines (max 1 (count-lines code-beg code-end)))
          (sig (secure-hash 'sha1 (concat content "|" opt)))
-         (pos (save-excursion
-                (goto-char code-end)
-                (line-end-position)))
          (block-end (save-excursion
                       (goto-char end)
                       (line-end-position))))
     (when (and valid-close (<= code-beg code-end))
       (list :beg beg :code-beg code-beg :code-end code-end
-            :end block-end :pos pos
+            :end block-end :pos block-end
             :indent indent :fence-line fence-line :closing-line closing-line
             :content content :sig sig :code-lines code-lines))))
 
@@ -1217,7 +1214,8 @@ and track the invisibility spec."
          (ov (seq-find (lambda (o)
                          (and (overlay-buffer o)
                               (overlay-get o 'md-mermaid-live)
-                              (= (or (overlay-get o 'md-mermaid-pos) -1) pos)))
+                              (or (= (or (overlay-get o 'md-mermaid-pos) -1) pos)
+                                  (= (overlay-start o) pos))))
                        md-mermaid-live--overlays)))
     (unless ov
       ;; Try to reuse any old live overlay at this position


### PR DESCRIPTION
## What

Fix two related bugs in `md-mermaid-live-mode` when tree-sitter markdown parsing is active.

## Bug 1: renders always marked "stale"

`md-mermaid-live--ts-build-block` set `:pos` to `code-end` (end of the last code line inside the fence) instead of `block-end` (end of the closing ` ``` ` line). The regex scanner sets both `:pos` and `:end` to `(match-end 0)`, so they are always equal there. With tree-sitter they differ, causing the stale check in `handle-job-exit` to always fail — rendered images were never applied to overlays, leaving permanent "Rendering #NNNN" placeholders.

**Fix:** Remove the separate `pos` binding and set `:pos` to `block-end`.

## Bug 2: duplicate overlays after text edits

After edits that shift buffer positions (e.g. inserting characters inside a fence), zero-length overlay markers move correctly but the stored `md-mermaid-pos` property retains the old value. `ensure-overlay` failed to find the existing overlay because:
- Primary match checks stored `md-mermaid-pos` (stale) — no match
- Fallback uses `overlays-at` which cannot find zero-length overlays (as noted in the code comment)

A new overlay was created alongside the old one, resulting in duplicate stacked images.

**Fix:** Add `(overlay-start o)` as a fallback in the primary match, which reflects the marker's actual (shifted) position.

## How to reproduce

1. Install the `markdown` tree-sitter grammar
2. Open a markdown file with mermaid code fences
3. Enable `md-mermaid-live-mode`
4. Bug 1: images never appear, `*md-mermaid-live*` shows `status=stale` for all jobs
5. Bug 2: edit text inside a fence — old and new images stack on top of each other

## Validation

- `python3 validate_elisp_syntax.py --files md-mermaid-live.el` → OK
- Byte-compile: only pre-existing `when-let` obsolescence warning (not introduced by this change)
- `scripts/gen-outlines.sh` → no outline changes
- Tested with both tree-sitter and regex scanner paths

Fixes #1